### PR TITLE
Changed PDF download to work in place instead of linking

### DIFF
--- a/app/components/PDF/Link.jsx
+++ b/app/components/PDF/Link.jsx
@@ -4,23 +4,40 @@ const PDFPuzzleDocument = require("./PuzzleDocument");
 
 // { blob: null, url: null, loading: true, error: null }
 
-const Redirect = ({ url }) => {
-  window.location.href = url;
+const Download = ({ url, fileName, onFinish }) => {
+  React.useEffect(() => {
+    var link = document.createElement('a');
+    document.body.appendChild(link); // required in FF, optional for Chrome
+    link.href = url;
+    link.download = fileName;
+    link.click();
+    link.remove();
+    onFinish();
+  }, []);
   return null;
 }
 
+const WithDownload = ({ loading, url, children, fileName, onFinish }) => (
+  <React.Fragment>
+    <Download loading={loading} url={url} fileName={fileName} onFinish={onFinish} />
+    {children}
+  </React.Fragment>
+);
+
+// <Download loading={loading} url={url} children={children} fileName={`${puzzle.title}.pdf`} onFinish={() => setLoading(false)} />
+
 module.exports = function PDFLink({ puzzle, children }) {
-  const [load, setLoad] = React.useState(false);
+  const [load, setLoading] = React.useState(false);
   if (!load) {
     return (
-      <a onClick={() => setLoad(true)} style={{ cursor: "pointer" }}>
+      <a onClick={() => setLoading(true)} style={{ cursor: "pointer" }}>
         {children}
       </a>
     );
   }
   return (
-    <BlobProvider document={<PDFPuzzleDocument puzzle={puzzle} />} fileName={`${puzzle.title}.pdf`} >
-      {({ loading, url }) => loading ? children : <Redirect url={url} />}
+    <BlobProvider document={<PDFPuzzleDocument puzzle={puzzle} />}>
+      {({ loading, url }) => loading ? children : (<WithDownload loading={loading} url={url} children={children} fileName={`${puzzle.title}.pdf`} onFinish={() => setLoading(false)} />)}
     </BlobProvider>
   );
 }

--- a/app/components/PDF/PuzzleDocument.jsx
+++ b/app/components/PDF/PuzzleDocument.jsx
@@ -140,7 +140,7 @@ module.exports = function PDFPuzzleDoc({ puzzle }) {
                 let curClue = allClues.shift();
                 usedClueHeight += clueHeight(curClue[2]);
                 return (
-                  <PrintClue dir={curClue[0]} num={curClue[1]} clue={curClue[2]} />
+                  <PrintClue key={i} dir={curClue[0]} num={curClue[1]} clue={curClue[2]} />
                 )
               }
             })}
@@ -154,7 +154,7 @@ module.exports = function PDFPuzzleDoc({ puzzle }) {
                     let curClue = allClues.shift();
                     usedClueHeight += clueHeight(curClue[2]);
                     return (
-                      <PrintClue dir={curClue[0]} num={curClue[1]} clue={curClue[2]} />
+                      <PrintClue key={i} dir={curClue[0]} num={curClue[1]} clue={curClue[2]} />
                     )
                   }
                 })}
@@ -165,7 +165,7 @@ module.exports = function PDFPuzzleDoc({ puzzle }) {
                   let curClue = allClues.shift();
                   usedClueHeight += clueHeight(curClue[2]);
                   return (
-                    <PrintClue dir={curClue[0]} num={curClue[1]} clue={curClue[2]} />
+                    <PrintClue key={i} dir={curClue[0]} num={curClue[1]} clue={curClue[2]} />
                   )
                 }
               })}
@@ -176,7 +176,7 @@ module.exports = function PDFPuzzleDoc({ puzzle }) {
                   let curClue = allClues.shift();
                   usedClueHeight += clueHeight(curClue[2]);
                   return (
-                    <PrintClue dir={curClue[0]} num={curClue[1]} clue={curClue[2]} />
+                    <PrintClue key={i} dir={curClue[0]} num={curClue[1]} clue={curClue[2]} />
                   )
                 }
               })}

--- a/app/components/Puzzle/Context.jsx
+++ b/app/components/Puzzle/Context.jsx
@@ -69,39 +69,39 @@ const PuzzleContextProvider = ({ initialGrid, puzzleId, children }) => {
   const prevCell = usePrevious(activeCell);
 
   // all pencil/locked suggestions are updated after a change to the activeCell
-  React.useEffect(() => {
-    if (activeCell.length && prevCell.length && activeCell[0] !== undefined && prevCell[0] !== undefined && activeCell !== prevCell) {
-      if (activeCell[0] === prevCell[0]){
-        if (grid[activeCell[0]][activeCell[1]].clue.acrossClueNumber !== grid[prevCell[0]][prevCell[1]].clue.acrossClueNumber){
-            clearAll(true);
-        } else {
-            if (downFilter && downFilter[0] !== null && downFilter[0] !== undefined){
-              setDownFilter([downFilter[0],downFilter[0][activeCell[1]-words.across.range[0]]]);
-            }
-            pencilHandling(prevCell[1], "across", activeCell[1] > prevCell[1]);
-        }
-      } else if (activeCell[1] === prevCell[1]){
-        if (grid[activeCell[0]][activeCell[1]].clue.downClueNumber !== grid[prevCell[0]][prevCell[1]].clue.downClueNumber){
-            clearAll(true);
-        } else {
-            if (acrossFilter && acrossFilter[0] !== null && acrossFilter[0] !== undefined){
-              setAcrossFilter([acrossFilter[0],acrossFilter[0][activeCell[0]-words.down.range[0]]]);
-            }
-            pencilHandling(prevCell[0], "down", activeCell[0] > prevCell[0]);
-        }
-      } else {
-        clearAll(true);
-      }
-      if (prevCell[0] && prevCell[0] !== undefined && grid[prevCell[0]][prevCell[1]].isRebus && grid[prevCell[0]][prevCell[1]].value.length <= 1){
-		grid[prevCell[0]][prevCell[1]].isRebus = false;
-	  }
-    } else if (prevCell && prevCell.length && prevCell[0] !== undefined) {
-	  if (grid[prevCell[0]][prevCell[1]].isRebus && grid[prevCell[0]][prevCell[1]].value.length <= 1){
-		grid[prevCell[0]][prevCell[1]].isRebus = false;
-	  }
-	}
+  // React.useEffect(() => {
+  //   if (activeCell.length && prevCell.length && activeCell[0] !== undefined && prevCell[0] !== undefined && activeCell !== prevCell) {
+  //     if (activeCell[0] === prevCell[0]){
+  //       if (grid[activeCell[0]][activeCell[1]].clue.acrossClueNumber !== grid[prevCell[0]][prevCell[1]].clue.acrossClueNumber){
+  //           clearAll(true);
+  //       } else {
+  //           if (downFilter && downFilter[0] !== null && downFilter[0] !== undefined){
+  //             setDownFilter([downFilter[0],downFilter[0][activeCell[1]-words.across.range[0]]]);
+  //           }
+  //           pencilHandling(prevCell[1], "across", activeCell[1] > prevCell[1]);
+  //       }
+  //     } else if (activeCell[1] === prevCell[1]){
+  //       if (grid[activeCell[0]][activeCell[1]].clue.downClueNumber !== grid[prevCell[0]][prevCell[1]].clue.downClueNumber){
+  //           clearAll(true);
+  //       } else {
+  //           if (acrossFilter && acrossFilter[0] !== null && acrossFilter[0] !== undefined){
+  //             setAcrossFilter([acrossFilter[0],acrossFilter[0][activeCell[0]-words.down.range[0]]]);
+  //           }
+  //           pencilHandling(prevCell[0], "down", activeCell[0] > prevCell[0]);
+  //       }
+  //     } else {
+  //       clearAll(true);
+  //     }
+  //     if (prevCell[0] && prevCell[0] !== undefined && grid[prevCell[0]][prevCell[1]].isRebus && grid[prevCell[0]][prevCell[1]].value.length <= 1){
+	// 	grid[prevCell[0]][prevCell[1]].isRebus = false;
+	//   }
+  //   } else if (prevCell && prevCell.length && prevCell[0] !== undefined) {
+	//   if (grid[prevCell[0]][prevCell[1]].isRebus && grid[prevCell[0]][prevCell[1]].value.length <= 1){
+	// 	grid[prevCell[0]][prevCell[1]].isRebus = false;
+	//   }
+	// }
 	
-  }, [activeCell]);
+  // }, [activeCell]);
 
   React.useEffect(() => {
     setWords(calculateCurrentWords());


### PR DESCRIPTION
We can't display this PDF in the browser first, because then when it tries to download it in the browser UI, it tries to fetch it from the URL again but the PDF doesn't exist at that URL anymore because we navigated away from the page 🤯 

This PR changes it so we just download it in place. I think it works with the icon staying in place, and should be able to download it multiple times if needed.

However, on download I do see this error in the console:
```
react-pdf.browser.es.js:5810 TypeError: Cannot read property 'hasGlyphForCodePoint' of null
    at react-pdf.browser.es.js:3890
    at Array.reduce (<anonymous>)
    at buildSubsetForFont (react-pdf.browser.es.js:3889)
    at react-pdf.browser.es.js:3900
    at Array.map (<anonymous>)
    at ignoreChars (react-pdf.browser.es.js:3899)
    at getFragments (react-pdf.browser.es.js:4013)
    at getAttributedString (react-pdf.browser.es.js:4019)
    at Text.layoutText (react-pdf.browser.es.js:4099)
    at Text.measureText (react-pdf.browser.es.js:4126)
```