### PR TITLE
Fix clear all pencils

### DIFF
--- a/app/components/Puzzle/Cell.jsx
+++ b/app/components/Puzzle/Cell.jsx
@@ -29,7 +29,7 @@ const PuzzleCell = ({ cell, row, column, puzzle }) => {
       puzzle.setActiveCell([row, column]);
     }
     if (e.metaKey || e.ctrlKey) {
-      puzzle.clearAll(false);
+      puzzle.clearAllPencils(false);
       puzzle.toggleBlackSquare(row, column);
     }
     if (e.altKey) {
@@ -51,7 +51,7 @@ const PuzzleCell = ({ cell, row, column, puzzle }) => {
     const currentCell = puzzle.grid[activeRow][activeColumn];
     e.preventDefault();
     if (e.key === ".") {
-      puzzle.clearAll(false);
+      puzzle.clearAllPencils(false);
       puzzle.toggleBlackSquare(activeRow, activeColumn);
       return;
     }


### PR DESCRIPTION
I renamed clearAll to clearAllPencils and only changed the references in Context. This PR changes the other two references to clearAll that I could find.