### PR TITLE
Fix early puzzle load

### DIFF
--- a/app/components/Puzzle/Cell.jsx
+++ b/app/components/Puzzle/Cell.jsx
@@ -51,7 +51,11 @@ const PuzzleCell = ({ cell, row, column, puzzle }) => {
     const currentCell = puzzle.grid[activeRow][activeColumn];
     e.preventDefault();
     if (e.key === ".") {
+<<<<<<< HEAD
       puzzle.clearActiveCellPencils();
+=======
+      puzzle.clearAllPencils(false);
+>>>>>>> Fixes clearAll v clearAllPencils rename bugs
       puzzle.toggleBlackSquare(activeRow, activeColumn);
       return;
     }

--- a/app/components/Puzzle/Cell.jsx
+++ b/app/components/Puzzle/Cell.jsx
@@ -51,11 +51,7 @@ const PuzzleCell = ({ cell, row, column, puzzle }) => {
     const currentCell = puzzle.grid[activeRow][activeColumn];
     e.preventDefault();
     if (e.key === ".") {
-<<<<<<< HEAD
       puzzle.clearActiveCellPencils();
-=======
-      puzzle.clearAllPencils(false);
->>>>>>> Fixes clearAll v clearAllPencils rename bugs
       puzzle.toggleBlackSquare(activeRow, activeColumn);
       return;
     }

--- a/app/components/Puzzle/Context.jsx
+++ b/app/components/Puzzle/Context.jsx
@@ -195,9 +195,6 @@ const PuzzleContextProvider = ({ initialGrid, puzzleId, children }) => {
       const numberedGrid = assignClueNumbersToGrid(savedPuzzle.grid);
       setGrid(numberedGrid);
       setClues(savedPuzzle.clues);
-      setActiveCell(savedPuzzle.activeCell);
-      setDirection(savedPuzzle.direction);
-      setWords(savedPuzzle.words);
       setSymmetry(savedPuzzle.symmetry);
       setSavedPuzzleId(puzzleId);
       clearActiveCellPencils();

--- a/app/components/Puzzle/Context.jsx
+++ b/app/components/Puzzle/Context.jsx
@@ -28,6 +28,7 @@ function getSavedPuzzle(id) {
 
 const PuzzleContextProvider = ({ initialGrid, puzzleId, children }) => {
   const emptyWord = { range: [], word: "" };
+  const [ready, setReady] = React.useState(false);
   const [savedPuzzleId, setSavedPuzzleId] = React.useState(null);
   const [activeCell, _setActiveCell] = React.useState([]);
   const [prevActiveCell, setPrevActiveCell] = React.useState([]);
@@ -186,6 +187,7 @@ const PuzzleContextProvider = ({ initialGrid, puzzleId, children }) => {
   // Initial instantiation of the saved puzzle and/or the saved puzzle
   // id used to save the puzzle going forward
   React.useEffect(() => {
+    setReady(false);
     const savedPuzzle = getSavedPuzzle(puzzleId);
     if (savedPuzzle) {
       setTitle(savedPuzzle.title);
@@ -202,6 +204,7 @@ const PuzzleContextProvider = ({ initialGrid, puzzleId, children }) => {
     } else {
       setSavedPuzzleId(puzzleId);
     }
+    setReady(true);
   }, [puzzleId]);
 
   const toggleDirection = () =>
@@ -480,6 +483,7 @@ const PuzzleContextProvider = ({ initialGrid, puzzleId, children }) => {
     words,
     grid,
     clues,
+    ready,
     symmetry,
     title,
     author,

--- a/app/components/Puzzle/index.jsx
+++ b/app/components/Puzzle/index.jsx
@@ -21,50 +21,52 @@ const Puzzle = () => {
 
   return (
     <PuzzleContext.Consumer>
-      {(puzzle) => (
-        <div>
-          <div
-            className="infomenublock"
-            style={{ maxWidth: puzzle.grid[0].length * 40 + 15 + "px" }}
-          >
-            <Title
-              titleWidth={puzzle.titleWidth}
-              authorWidth={puzzle.authorWidth}
-              setTitleWidth={puzzle.setTitleWidth}
-              setAuthorWidth={puzzle.setAuthorWidth}
-              title={puzzle.title}
-              author={puzzle.author}
-              setTitle={puzzle.setTitle}
-              setAuthor={puzzle.setAuthor}
-            />
-            <Menu puzzle={puzzle} />
-          </div>
-          <div className="puzzle-container">
+      {(puzzle) =>
+        !puzzle.ready ? null : (
+          <div>
             <div
-              className={
-                "puzzle-grid " +
-                gridSizeDesc(puzzle.grid[0].length) +
-                " " +
-                puzzle.zoomed
-              }
+              className="infomenublock"
+              style={{ maxWidth: puzzle.grid[0].length * 40 + 15 + "px" }}
             >
-              {puzzle.grid.map((columns, i) => (
-                <Row key={`row-${i}`} row={i} columns={columns} />
-              ))}
+              <Title
+                titleWidth={puzzle.titleWidth}
+                authorWidth={puzzle.authorWidth}
+                setTitleWidth={puzzle.setTitleWidth}
+                setAuthorWidth={puzzle.setAuthorWidth}
+                title={puzzle.title}
+                author={puzzle.author}
+                setTitle={puzzle.setTitle}
+                setAuthor={puzzle.setAuthor}
+              />
+              <Menu puzzle={puzzle} />
             </div>
-            <CurrentClues
-              across={puzzle.words.across}
-              down={puzzle.words.down}
-              puzzle={puzzle}
-            />
-            <AllClues
-              across={puzzle.words.across}
-              down={puzzle.words.down}
-              puzzle={puzzle}
-            />
+            <div className="puzzle-container">
+              <div
+                className={
+                  "puzzle-grid " +
+                  gridSizeDesc(puzzle.grid[0].length) +
+                  " " +
+                  puzzle.zoomed
+                }
+              >
+                {puzzle.grid.map((columns, i) => (
+                  <Row key={`row-${i}`} row={i} columns={columns} />
+                ))}
+              </div>
+              <CurrentClues
+                across={puzzle.words.across}
+                down={puzzle.words.down}
+                puzzle={puzzle}
+              />
+              <AllClues
+                across={puzzle.words.across}
+                down={puzzle.words.down}
+                puzzle={puzzle}
+              />
+            </div>
           </div>
-        </div>
-      )}
+        )
+      }
     </PuzzleContext.Consumer>
   );
 };


### PR DESCRIPTION
This PR makes the puzzle wait to render until it's ready, which means the saved puzzle state has already been evaluated and either the saved puzzle is loaded or a new puzzle has been saved and ready to load.

Also, it stops loading active cell and direction state from saved puzzles, which is unnecessary.